### PR TITLE
Fix multi-word label wrapping when scrolling left

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -130,6 +130,7 @@ $initial-reveal: 50%;
 }
 .#{$prefix}-reveal[data-beer-label]:after {
   left: 1.5rem;
+  white-space: nowrap;
 }
 .#{$prefix}-slider[data-beer-label=""]:after,
 .#{$prefix}-reveal[data-beer-label=""]:after {


### PR DESCRIPTION
Only happens in the reveal text on the left, but when you scroll slowly to the left using a multi-word label like `data-beer-label="Feature On"`.